### PR TITLE
feat(imc-app): integrar formulario y historial de IMC

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,61 @@
+import { useState } from 'react';
+import { ThemeProvider, createTheme, CssBaseline, Box, Typography } from '@mui/material';
+import ImcForm from './ImcForm';
+import Historial from './Historial';
 
-import ImcForm from './ImcForm'
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#1976d2',
+    },
+    secondary: {
+      main: '#dc004e',
+    },
+  },
+});
 
 function App() {
+  const [refreshHistorial, setRefreshHistorial] = useState(0);
+
+  // Función para actualizar el historial cuando se hace un cálculo
+  const handleCalculoRealizado = () => {
+    setRefreshHistorial(prev => prev + 1);
+  };
 
   return (
-    <>
-     <div>
-      <ImcForm />
-    </div>
-    </>
-  )
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Box sx={{ minHeight: '100vh', bgcolor: 'grey.50', py: 3 }}>
+        <Box sx={{ maxWidth: 1200, mx: 'auto', px: 3 }}>
+          
+          {/* Título principal */}
+          <Typography variant="h4" align="center" gutterBottom sx={{ mb: 4 }}>
+            Calculadora de IMC
+          </Typography>
+
+          {/* Layout responsive con flexbox */}
+          <Box sx={{ 
+            display: 'flex', 
+            gap: 3, 
+            flexDirection: { xs: 'column', md: 'row' },
+            alignItems: 'flex-start'
+          }}>
+            
+            {/* Columna izquierda: Formulario */}
+            <Box sx={{ flex: '0 0 auto', width: { xs: '100%', md: '400px' } }}>
+              <ImcForm onCalculoRealizado={handleCalculoRealizado} />
+            </Box>
+
+            {/* Columna derecha: Historial */}
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Historial shouldRefresh={refreshHistorial} />
+            </Box>
+
+          </Box>
+        </Box>
+      </Box>
+    </ThemeProvider>
+  );
 }
 
-export default App
+export default App;

--- a/src/Historial.tsx
+++ b/src/Historial.tsx
@@ -1,0 +1,212 @@
+import { useState, useEffect } from "react";
+import {
+  Box,
+  Typography,
+  Paper,
+  List,
+  ListItem,
+  ListItemText,
+  Divider,
+  Chip,
+  Alert,
+  CircularProgress,
+  IconButton,
+} from "@mui/material";
+import { Refresh as RefreshIcon } from "@mui/icons-material";
+import axios from "axios";
+
+// ---- MOCK ----
+const datosMock = [
+  {
+    id: 1,
+    peso: 70,
+    altura: 1.75,
+    imc: 22.86,
+    categoria: "Normal",
+    fecha: new Date().toISOString(),
+  },
+  {
+    id: 2,
+    peso: 85,
+    altura: 1.7,
+    imc: 29.41,
+    categoria: "Sobrepeso",
+    fecha: new Date().toISOString(),
+  },
+  {
+    id: 3,
+    peso: 48,
+    altura: 1.7,
+    imc: 16.62,
+    categoria: "Bajo peso",
+    fecha: new Date().toISOString(),
+  },
+  {
+    id: 4,
+    peso: 95,
+    altura: 1.6,
+    imc: 37.11,
+    categoria: "Obesidad",
+    fecha: new Date().toISOString(),
+  },
+];
+
+// ---- SWITCH ENTRE MOCK Y BACK ----
+const USE_MOCK = true; // ⬅️ cambia a false si querés probar con el back
+
+interface CalculoIMC {
+  id: number;
+  peso: number;
+  altura: number;
+  imc: number;
+  categoria: string;
+  fecha: string;
+}
+
+interface HistorialProps {
+  shouldRefresh?: number;
+}
+
+export default function Historial({ shouldRefresh }: HistorialProps) {
+  const [historial, setHistorial] = useState<CalculoIMC[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  //const API_URL = import.meta.env.VITE_VERCEL_URL;el
+  const API_URL = "http://localhost:3000"; // 👈 usa el back si está levantado
+
+  // Cargar historial
+  const cargarHistorial = async () => {
+    if (USE_MOCK) {
+      setHistorial(datosMock);
+      return;
+    }
+
+    setLoading(true);
+    setError("");
+    try {
+      const response = await axios.get(`${API_URL}/imc/historial`);
+      setHistorial(response.data);
+    } catch (err) {
+      console.error("Error cargando historial:", err);
+      setError("Error al cargar historial");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Monta y actualiza cuando cambia shouldRefresh
+  useEffect(() => {
+    cargarHistorial();
+  }, [shouldRefresh]);
+
+  const formatearFecha = (fecha: string) => {
+    return new Date(fecha).toLocaleDateString("es-AR", {
+      day: "2-digit",
+      month: "2-digit",
+      year: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  const getColorCategoria = (categoria: string) => {
+    switch (categoria.toLowerCase()) {
+      case "bajo peso":
+        return "info";
+      case "normal":
+        return "success";
+      case "sobrepeso":
+        return "warning";
+      case "obesidad":
+        return "error";
+      default:
+        return "default";
+    }
+  };
+
+  return (
+    <Paper elevation={4} sx={{ p: 3, borderRadius: 3 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          mb: 2,
+        }}
+      >
+        <Typography variant="h5">Historial ({historial.length})</Typography>
+        <IconButton
+          onClick={cargarHistorial}
+          disabled={loading}
+          color="primary"
+          size="small"
+        >
+          <RefreshIcon />
+        </IconButton>
+      </Box>
+
+      {loading && (
+        <Box sx={{ display: "flex", justifyContent: "center", p: 2 }}>
+          <CircularProgress size={20} />
+        </Box>
+      )}
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      {!loading && !error && (
+        <>
+          {historial.length === 0 ? (
+            <Alert severity="info">
+              No hay cálculos registrados. ¡Realiza tu primera medición!
+            </Alert>
+          ) : (
+            <List sx={{ maxHeight: 400, overflow: "auto" }}>
+              {historial.map((calculo, index) => (
+                <Box key={calculo.id}>
+                  <ListItem sx={{ px: 0, py: 1 }}>
+                    <ListItemText
+                      primary={
+                        <Box
+                          sx={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            alignItems: "center",
+                          }}
+                        >
+                          <Typography variant="body1" component="span">
+                            <strong>IMC: {calculo.imc.toFixed(2)}</strong>
+                          </Typography>
+                          <Chip
+                            label={calculo.categoria}
+                            color={getColorCategoria(calculo.categoria) as any}
+                            size="small"
+                          />
+                        </Box>
+                      }
+                      secondary={
+                        <Box sx={{ mt: 0.5 }}>
+                          <Typography variant="body2" color="text.secondary">
+                            {calculo.peso} kg • {calculo.altura} m
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            {formatearFecha(calculo.fecha)}
+                          </Typography>
+                        </Box>
+                      }
+                    />
+                  </ListItem>
+                  {index < historial.length - 1 && <Divider />}
+                </Box>
+              ))}
+            </List>
+          )}
+        </>
+      )}
+    </Paper>
+  );
+}

--- a/src/ImcForm.tsx
+++ b/src/ImcForm.tsx
@@ -1,4 +1,3 @@
-import SplitText from "./components/SplitText";
 import { useState } from "react";
 import axios from "axios";
 import {
@@ -25,12 +24,17 @@ interface FormErrors {
   peso?: string;
 }
 
-export default function ImcForm() {
+interface ImcFormProps {
+  onCalculoRealizado?: () => void; // Callback para notificar que se hizo un cálculo
+}
+
+export default function ImcForm({ onCalculoRealizado }: ImcFormProps) {
   const [altura, setAltura] = useState("");
   const [peso, setPeso] = useState("");
   const [resultado, setResultado] = useState<ImcResult | null>(null);
   const [error, setError] = useState("");
   const [formErrors, setFormErrors] = useState<FormErrors>({});
+  const [calculando, setCalculando] = useState(false);
 
   // Validación en tiempo real para altura
   const handleAlturaChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -73,21 +77,20 @@ export default function ImcForm() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    // Limpiar errores previos
     setError("");
     setResultado(null);
+    setCalculando(true);
 
-    // Validar el formulario completo
+    // Validaciones
     const validation = validateImcForm(altura, peso);
-
     if (!validation.isValid) {
       setError(
         validation.error || "Por favor, corrige los errores del formulario"
       );
+      setCalculando(false);
       return;
     }
 
-    // Validaciones específicas de cada campo
     const alturaValidation = validateAltura(altura);
     const pesoValidation = validatePeso(peso);
 
@@ -96,11 +99,14 @@ export default function ImcForm() {
         altura: alturaValidation.isValid ? undefined : alturaValidation.error,
         peso: pesoValidation.isValid ? undefined : pesoValidation.error,
       });
+      setCalculando(false);
       return;
     }
 
     try {
       const API_URL = import.meta.env.VITE_VERCEL_URL;
+
+      // Calcular y guardar automáticamente
       const response = await axios.post(`${API_URL}/imc/calcular`, {
         altura: parseFloat(altura),
         peso: parseFloat(peso),
@@ -109,122 +115,103 @@ export default function ImcForm() {
       setResultado(response.data);
       setError("");
       setFormErrors({});
+
+      // Notificar al componente padre que se realizó un cálculo
+      if (onCalculoRealizado) {
+        onCalculoRealizado();
+      }
     } catch (err) {
       console.error("Error calculating IMC:", err);
       setError(
         "Error al calcular el IMC. Verifica si el backend está funcionando correctamente."
       );
       setResultado(null);
+    } finally {
+      setCalculando(false);
     }
   };
 
-  // Verificar si hay errores en el formulario
   const hasErrors = Object.values(formErrors).some(
     (error) => error !== undefined
   );
 
   return (
-    <Box
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "center",
-        alignItems: "center",
-        minHeight: "80vh",
-        mt: 5,
-      }}
-    >
-      <Box
-        sx={{
-          fontSize: "3rem",
-          fontWeight: "bold",
-          textAlign: "center",
-          color: "black",
-        }}
-      >
-        <SplitText
-          text="¡Hola Bienvenido!"
-          delay={100}
-          duration={0.6}
-          ease="power3.out"
-          splitType="chars"
-          from={{ opacity: 0, y: 40 }}
-          to={{ opacity: 1, y: 0 }}
-          threshold={0.1}
-          rootMargin="-100px"
+    <Paper elevation={4} sx={{ p: 3, borderRadius: 3 }}>
+      <Typography variant="h5" align="center" gutterBottom>
+        Nueva Medición
+      </Typography>
+
+      <Box component="form" onSubmit={handleSubmit} noValidate>
+        <TextField
+          label="Altura (m)"
+          type="number"
+          value={altura}
+          onChange={handleAlturaChange}
+          error={!!formErrors.altura}
+          helperText={
+            formErrors.altura || "Ingresa tu altura en metros (ej: 1.75)"
+          }
+          inputProps={{
+            min: "0.1",
+            max: "3.0",
+            step: "0.01",
+          }}
+          fullWidth
+          margin="normal"
+          required
+          disabled={calculando}
         />
+
+        <TextField
+          label="Peso (kg)"
+          type="number"
+          value={peso}
+          onChange={handlePesoChange}
+          error={!!formErrors.peso}
+          helperText={formErrors.peso || "Ingresa tu peso en kilogramos"}
+          inputProps={{
+            min: "0.1",
+            max: "500",
+            step: "0.1",
+          }}
+          fullWidth
+          margin="normal"
+          required
+          disabled={calculando}
+        />
+
+        <Button
+          type="submit"
+          variant="contained"
+          fullWidth
+          disabled={hasErrors || !altura || !peso || calculando}
+          sx={{ mt: 2, borderRadius: 2, py: 1.5 }}
+        >
+          {calculando ? "Calculando..." : "Calcular IMC"}
+        </Button>
       </Box>
 
-      <Paper elevation={4} sx={{ p: 4, borderRadius: 3, width: 400 }}>
-        <Typography variant="h4" align="center" gutterBottom>
-          Calculadora de IMC
-        </Typography>
-
-        <Box component="form" onSubmit={handleSubmit} noValidate>
-          <TextField
-            label="Altura (m)"
-            type="number"
-            value={altura}
-            onChange={handleAlturaChange}
-            error={!!formErrors.altura}
-            helperText={
-              formErrors.altura || "Ingresa tu altura en metros (ej: 1.75)"
-            }
-            inputProps={{
-              min: "0.1",
-              max: "3.0",
-              step: "0.01",
-            }}
-            fullWidth
-            margin="normal"
-            required
-          />
-
-          <TextField
-            label="Peso (kg)"
-            type="number"
-            value={peso}
-            onChange={handlePesoChange}
-            error={!!formErrors.peso}
-            helperText={formErrors.peso || "Ingresa tu peso en kilogramos"}
-            inputProps={{
-              min: "0.1",
-              max: "500",
-              step: "0.1",
-            }}
-            fullWidth
-            margin="normal"
-            required
-          />
-
-          <Button
-            type="submit"
-            variant="contained"
-            fullWidth
-            disabled={hasErrors || !altura || !peso}
-            sx={{ mt: 2, borderRadius: 2 }}
-          >
-            Calcular IMC
-          </Button>
+      {/* Resultado */}
+      {resultado && (
+        <Box sx={{ mt: 3 }}>
+          <Alert severity="success">
+            <Typography variant="h6">
+              IMC: {resultado.imc.toFixed(2)}
+            </Typography>
+            <Typography>Categoría: {resultado.categoria}</Typography>
+            <Typography variant="body2" sx={{ mt: 1, fontStyle: "italic" }}>
+              ✅ Guardado en el historial
+            </Typography>
+          </Alert>
         </Box>
+      )}
 
-        {resultado && (
-          <Box sx={{ mt: 3 }}>
-            <Alert severity="success">
-              <Typography variant="h6">
-                IMC: {resultado.imc.toFixed(2)}
-              </Typography>
-              <Typography>Categoría: {resultado.categoria}</Typography>
-            </Alert>
-          </Box>
-        )}
-
-        {error && (
-          <Box sx={{ mt: 3 }}>
-            <Alert severity="error">{error}</Alert>
-          </Box>
-        )}
-      </Paper>
-    </Box>
+      {/* Error */}
+      {error && (
+        <Box sx={{ mt: 3 }}>
+          <Alert severity="error">{error}</Alert>
+        </Box>
+      )}
+    </Paper>
   );
 }


### PR DESCRIPTION
- Agrega callback onCalculoRealizado para notificar a App.
- Crea componente Historial para mostrar lista de cálculos de IMC.
- Historial soporta refresco automático al realizar un nuevo cálculo.
- Maneja loading, errores de conexión y estado vacío.
- Preparado para usar datos mock mientras el backend no está disponible (solo para prueba).
- UI basada en MUI Material, consistente con la versión anterior (se quito el SplitText).